### PR TITLE
Makaira external link categories

### DIFF
--- a/src/PersistenceLayer/Normalizer/CategoryNormalizer.php
+++ b/src/PersistenceLayer/Normalizer/CategoryNormalizer.php
@@ -51,7 +51,7 @@ class CategoryNormalizer implements NormalizerInterface
             'keywords'         => $object->getTranslation('keywords'),
             'customFields'     => $this->processCustomFields($object->getCustomFields(), $salesChannelContext),
             'active'           => $object->getActive(),
-            'hidden'           => !$object->getVisible(),
+            'hidden'           => !$object->getVisible() || $object->getType() === 'link',
             'images'           => $object->getMedia() ? ['/' . $object->getMedia()->getPath()] : null,
             'url'              => '/' . $this->getSeoUrlPath($object->getSeoUrls(), $salesChannelContext->getLanguageId()),
             'timestamp'        => ($object->getUpdatedAt() ?? $object->getCreatedAt())->format('Y-m-d H:i:s'),


### PR DESCRIPTION
Modify `CategoryNormalizer` to set `hidden: true` for categories of type 'link'.

External link categories (`type: link`) were appearing in Makaira search results, but they should be hidden. This change ensures such categories are marked as `hidden: true` during export, allowing Makaira's filters to properly exclude them from search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-f66e8d9f-a2cd-4291-9115-471311027ccf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f66e8d9f-a2cd-4291-9115-471311027ccf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

